### PR TITLE
Explicitly specifiy dependency on minitest > 5.0.0

### DIFF
--- a/pact-consumer-minitest.gemspec
+++ b/pact-consumer-minitest.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pact", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest", ">= 5.0.0"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "httparty"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
The `#after_run` hook method, which is used by this gem, was introduced in [minitest 5.0.0](https://github.com/seattlerb/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6).

Make this dependency explicit so that users of the gem know.